### PR TITLE
enhance precision from 6 to 8 digits after the decimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ The following parameters will be filled in:
 Example values for `staticmapurl`:
 
 * [Google Maps](https://developers.google.com/maps/documentation/static-maps/intro):
-`https://maps.googleapis.com/maps/api/staticmap?markers=%f,%f&size=%dx%d&key=%s`.
+`https://maps.googleapis.com/maps/api/staticmap?markers=%1$.8f,%2$.8f&size=%3$dx%4$d&key=%5$s`.
 * [Open Street Map](https://wiki.openstreetmap.org/wiki/StaticMapLite):
-`http://staticmap.openstreetmap.de/staticmap.php?center=%1$f,%2$f&markers=%1$f,%2$f,red-pushpin&size=%3$dx%4$d&zoom=%6$d`
+`http://staticmap.openstreetmap.de/staticmap.php?center=%1$.8f,%2$.8f&markers=%1$.10f,%2$.10f,red-pushpin&size=%3$dx%4$d&zoom=%6$d`
 * [MapQuest](https://developer.mapquest.com/documentation/static-map-api/v5/):
-`https://www.mapquestapi.com/staticmap/v5/map?locations=%f,%f&size=%d,%d&key=%s&zoom=%d`
+`https://www.mapquestapi.com/staticmap/v5/map?locations=%1$.8f,%2$.8f&size=%3$d,%4$d&zoom=%6$d&key=%5$s`
 
 Note that you can also use [QR Code Generator](http://goqr.me/api/doc/create-qr-code/) as thumbnail generator.
 The resulting value for `staticmapurl` then looks like: `https://api.qrserver.com/v1/create-qr-code/?data=geo:%f,%f&size=%dx%d&bgcolor=eee`

--- a/main.sv-geolocation.php
+++ b/main.sv-geolocation.php
@@ -14,8 +14,8 @@ class AttributeGeolocation extends AttributeDBField
 	public function GetSQLColumns($bFullSpec = false)
 	{
 		$aColumns = array();
-		$aColumns[$this->GetCode().'_lat'] = 'DECIMAL(8,6)';
-		$aColumns[$this->GetCode().'_lng'] = 'DECIMAL(9,6)';
+		$aColumns[$this->GetCode().'_lat'] = 'DECIMAL(10,8)';
+		$aColumns[$this->GetCode().'_lng'] = 'DECIMAL(11,8)';
 		return $aColumns;
 	}
 	
@@ -154,11 +154,11 @@ class AttributeGeolocation extends AttributeDBField
 		{
 			case 'rijksdriehoek':
 			case 'rd':
-				if ($value instanceof ormGeolocation) return sprintf('%f,%f', $value->getRijksdriehoekX(), $value->getRijksdriehoekY());
+				if ($value instanceof ormGeolocation) return sprintf('%.8f,%.8f', $value->getRijksdriehoekX(), $value->getRijksdriehoekY());
 				else return;
 
 			case 'wgs_84':
-				if ($value instanceof ormGeolocation) return sprintf('%f,%f', $value->getLatitude(), $value->getLongitude());
+				if ($value instanceof ormGeolocation) return sprintf('%.8f,%.8f', $value->getLatitude(), $value->getLongitude());
 				else return;
 
 			default:
@@ -229,14 +229,14 @@ class AttributeGeolocation extends AttributeDBField
 		switch (utils::GetConfig()->GetModuleSetting('sv-geolocation', 'provider'))
 		{
 			case 'GoogleMaps':
-				if ($sApiKey) return 'https://maps.googleapis.com/maps/api/staticmap?markers=%1$f,%2$f&size=%3$dx%4$d&key=%5$s';
+				if ($sApiKey) return 'https://maps.googleapis.com/maps/api/staticmap?markers=%1$.8f,%2$.8f&size=%3$dx%4$d&key=%5$s';
 				break;
 				
 			case 'OpenStreetMap':
-				return 'http://staticmap.openstreetmap.de/staticmap.php?center=%1$f,%2$f&markers=%1$f,%2$f,red-pushpin&size=%3$dx%4$d&zoom=%6$d';
+				return 'http://staticmap.openstreetmap.de/staticmap.php?center=%1$.8f,%2$.8f&markers=%1$.10f,%2$.10f,red-pushpin&size=%3$dx%4$d&zoom=%6$d';
 				
 			case 'MapQuest':
-				if ($sApiKey) return 'https://www.mapquestapi.com/staticmap/v5/map?locations=%1$f,%2$f&size=%3$d,%4$d&zoom=%6$d&key=%5$s';
+				if ($sApiKey) return 'https://www.mapquestapi.com/staticmap/v5/map?locations=%1$.8f,%2$.8f&size=%3$d,%4$d&zoom=%6$d&key=%5$s';
 				break;
 		}
 		return null;
@@ -343,7 +343,7 @@ class ormGeolocation implements JsonSerializable
 	
 	public function __toString()
 	{
-		return sprintf('%f,%f', $this->fLatitude, $this->fLongitude);
+		return sprintf('%.8f,%.8f', $this->fLatitude, $this->fLongitude);
 	}
 	
 	/**


### PR DESCRIPTION
When copying coordinates, the exact location may be lost or slightly altered due to the truncation of digits after the decimal point.